### PR TITLE
enhance `SurrealKysely.relate` api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,16 @@ import {fetch} from 'undici'
 
 interface Database {
   person: {
-    id: GeneratedAlways<string>
     first_name: string | null
     last_name: string | null
     age: number
   }
+  own: SurrealEdge<{
+    time: {
+      adopted: string
+    } | null
+  }>
   pet: {
-    id: GeneratedAlways<string>
     name: string
     owner_id: string | null
   }
@@ -100,13 +103,16 @@ import {fetch} from 'undici'
 
 interface Database {
   person: {
-    id: GeneratedAlways<string>
     first_name: string | null
     last_name: string | null
     age: number
   }
+  own: SurrealEdge<{
+    time: {
+      adopted: string
+    } | null
+  }>
   pet: {
-    id: GeneratedAlways<string>
     name: string
     owner_id: string | null
   }
@@ -140,9 +146,9 @@ await db
 #### Why not write a query builder from scratch
 
 Kysely is growing to be THE sql query builder solution in the typescript ecosystem.
-Koskimas' dedication, attention to detail, experience from creating objection.js, project structure, simplicity, design patterns and philosophy, 
-made adding code to that project a really good experience as a contributor. Taking 
-what's great about that codebase, and patching in SurrealQL stuff seems like an easy 
+Koskimas' dedication, attention to detail, experience from creating objection.js, project structure, simplicity, design patterns and philosophy,
+made adding code to that project a really good experience as a contributor. Taking
+what's great about that codebase, and patching in SurrealQL stuff seems like an easy
 win in the short-medium term.
 
 ## License

--- a/src/operation-node/operation-node.ts
+++ b/src/operation-node/operation-node.ts
@@ -1,4 +1,4 @@
-export type SurrealOperationNodeKind = 'CreateQueryNode' | 'ReturnNode' | 'RelateQueryNode'
+export type SurrealOperationNodeKind = 'CreateQueryNode' | 'ReturnNode' | 'RelateQueryNode' | 'VertexNode'
 
 export interface SurrealOperationNode {
   readonly kind: SurrealOperationNodeKind
@@ -8,6 +8,7 @@ const surrealKindDictionary: Record<SurrealOperationNodeKind, true> = {
   CreateQueryNode: true,
   RelateQueryNode: true,
   ReturnNode: true,
+  VertexNode: true,
 }
 
 export function isSurrealOperationNode(node: {kind: string}): node is SurrealOperationNode {

--- a/src/operation-node/relate-query-node.ts
+++ b/src/operation-node/relate-query-node.ts
@@ -1,14 +1,14 @@
 import type {ColumnUpdateNode, TableNode, ValueNode} from 'kysely'
 
-import type {VertexNode} from '../parser/vertex-expression-parser.js'
 import {freeze} from '../util/object-utils.js'
 import type {SurrealOperationNode} from './operation-node.js'
 import type {ReturnNode} from './return-node.js'
+import type {VertexNode} from './vertex-node.js'
 
 export interface RelateQueryNode extends SurrealOperationNode {
   readonly kind: 'RelateQueryNode'
   readonly from?: VertexNode
-  readonly table: TableNode
+  readonly edge: TableNode
   readonly to?: VertexNode
   readonly content?: ValueNode
   readonly set?: ReadonlyArray<ColumnUpdateNode>
@@ -20,10 +20,10 @@ export const RelateQueryNode = freeze({
     return node.kind === 'RelateQueryNode'
   },
 
-  create(table: TableNode): RelateQueryNode {
+  create(edge: TableNode): RelateQueryNode {
     return freeze({
       kind: 'RelateQueryNode',
-      table,
+      edge,
     })
   },
 

--- a/src/operation-node/vertex-node.ts
+++ b/src/operation-node/vertex-node.ts
@@ -1,0 +1,24 @@
+import type {RawNode, SelectQueryNode, TableNode} from 'kysely'
+
+import {freeze} from '../util/object-utils.js'
+import type {SurrealOperationNode} from './operation-node.js'
+
+export type VertexExpressionNode = TableNode | ReadonlyArray<TableNode> | RawNode | SelectQueryNode
+
+export interface VertexNode extends SurrealOperationNode {
+  readonly kind: 'VertexNode'
+  readonly vertex: VertexExpressionNode
+}
+
+export const VertexNode = freeze({
+  is(node: SurrealOperationNode): node is VertexNode {
+    return node.kind === 'VertexNode'
+  },
+
+  create(vertex: VertexExpressionNode): VertexNode {
+    return freeze({
+      kind: 'VertexNode',
+      vertex,
+    })
+  },
+})

--- a/src/parser/vertex-expression-parser.ts
+++ b/src/parser/vertex-expression-parser.ts
@@ -1,15 +1,23 @@
-import {TableNode, type AnySelectQueryBuilder, type RawBuilder, type RawNode, type SelectQueryNode} from 'kysely'
+import {TableNode, type AnySelectQueryBuilder, type RawBuilder} from 'kysely'
 
-import type {SurrealRecordId} from '../util/surreal-types.js'
+import {VertexNode} from '../operation-node/vertex-node.js'
+import {isReadonlyArray} from '../util/object-utils.js'
+import type {AnySpecificVertex} from '../util/surreal-types.js'
 
-export type VertexExpression<DB> = SurrealRecordId<DB> | AnySelectQueryBuilder | RawBuilder<any>
-
-export type VertexNode = TableNode | RawNode | SelectQueryNode
+export type VertexExpression<DB> =
+  | AnySpecificVertex<DB>
+  | ReadonlyArray<AnySpecificVertex<DB>>
+  | AnySelectQueryBuilder
+  | RawBuilder<any>
 
 export function parseVertexExpression<DB>(expression: VertexExpression<DB>): VertexNode {
   if (typeof expression === 'string') {
-    return TableNode.create(expression)
+    return VertexNode.create(TableNode.create(expression))
   }
 
-  return expression.toOperationNode()
+  if (isReadonlyArray(expression)) {
+    return VertexNode.create(expression.map(TableNode.create))
+  }
+
+  return VertexNode.create(expression.toOperationNode())
 }

--- a/src/query-builder/relate-query-builder.ts
+++ b/src/query-builder/relate-query-builder.ts
@@ -19,7 +19,7 @@ import {
 import {parseVertexExpression, type VertexExpression} from '../parser/vertex-expression-parser.js'
 import {preventAwait} from '../util/prevent-await.js'
 import type {QueryId} from '../util/query-id.js'
-import type {AnyTable, SurrealRecordId} from '../util/surreal-types.js'
+import type {AnySpecificVertex, AnyVertexGroup} from '../util/surreal-types.js'
 import type {MergePartial} from '../util/type-utils.js'
 import type {ReturnInterface} from './return-interface.js'
 import type {SetContentInterface} from './set-content-interface.js'
@@ -34,15 +34,41 @@ export class RelateQueryBuilder<DB, TB extends keyof DB, O = DB[TB]>
   }
 
   /**
+   * Sets the given record/s as inbound vertex/vertices of a {@link SurrealKysely.relate | relate} query's edge.
    *
+   * To set outbound vertex/vertices, see {@link from}.
+   *
+   * ### Examples
+   *
+   * ```ts
+   * import {sql} from 'kysely'
+   *
+   * const relation = await db
+   *   .relate('write')
+   *   .from('user:tobie')
+   *   .to('article:surreal')
+   *   .set({
+   *     'time.written': sql`time::now()`,
+   *   })
+   *   .executeTakeFirst()
+   * ```
+   *
+   * The generated SurrealQL:
+   *
+   * ```sql
+   * relate user:tobie -> write -> article:surreal
+   * set time.written = time::now();
+   * ```
    */
-  from(table: AnyTable<DB>, id: string | number): RelateQueryBuilder<DB, TB, O>
+  from(table: AnyVertexGroup<DB>, id: string | number): RelateQueryBuilder<DB, TB, O>
 
-  from(record: SurrealRecordId<DB>): RelateQueryBuilder<DB, TB, O>
+  from(record: AnySpecificVertex<DB>): RelateQueryBuilder<DB, TB, O>
+
+  from(records: ReadonlyArray<AnySpecificVertex<DB>>): RelateQueryBuilder<DB, TB, O>
 
   from(expression: AnySelectQueryBuilder | RawBuilder<any>): RelateQueryBuilder<DB, TB, O>
 
-  from(target: AnyTable<DB> | VertexExpression<DB>, id?: string | number): any {
+  from(target: AnyVertexGroup<DB> | VertexExpression<DB>, id?: string | number): any {
     const expression = id !== undefined ? `${String(target)}:${id}` : target
 
     return new RelateQueryBuilder({
@@ -52,15 +78,41 @@ export class RelateQueryBuilder<DB, TB extends keyof DB, O = DB[TB]>
   }
 
   /**
+   * Sets the given record/s as outbound vertex/vertices of a {@link SurrealKysely.relate | relate} query's edge.
    *
+   * To set inbound vertex/vertices, see {@link to}.
+   *
+   * ### Examples:
+   *
+   * ```ts
+   * import {sql} from 'kysely'
+   *
+   * const relation = await db
+   *   .relate('write')
+   *   .from('user:tobie')
+   *   .to('article:surreal')
+   *   .set({
+   *     'time.written': sql`time::now()`,
+   *   })
+   *   .executeTakeFirst()
+   * ```
+   *
+   * The generated SurrealQL:
+   *
+   * ```sql
+   * relate user:tobie -> write -> article:surreal
+   * set time.written = time::now();
+   * ```
    */
-  to(table: AnyTable<DB>, id: string | number): RelateQueryBuilder<DB, TB, O>
+  to(table: AnyVertexGroup<DB>, id: string | number): RelateQueryBuilder<DB, TB, O>
 
-  to(record: SurrealRecordId<DB>): RelateQueryBuilder<DB, TB, O>
+  to(record: AnySpecificVertex<DB>): RelateQueryBuilder<DB, TB, O>
+
+  to(records: ReadonlyArray<AnySpecificVertex<DB>>): RelateQueryBuilder<DB, TB, O>
 
   to(expression: AnySelectQueryBuilder | RawBuilder<any>): RelateQueryBuilder<DB, TB, O>
 
-  to(target: AnyTable<DB> | VertexExpression<DB>, id?: string | number): any {
+  to(target: AnyVertexGroup<DB> | VertexExpression<DB>, id?: string | number): any {
     const expression = id !== undefined ? `${String(target)}:${id}` : target
 
     return new RelateQueryBuilder({

--- a/src/query-compiler/query-compiler.ts
+++ b/src/query-compiler/query-compiler.ts
@@ -13,10 +13,11 @@ import {
   type SurrealOperationNode,
   type SurrealOperationNodeKind,
 } from '../operation-node/operation-node.js'
-import {RelateQueryNode} from '../operation-node/relate-query-node.js'
+import type {RelateQueryNode} from '../operation-node/relate-query-node.js'
 import type {ReturnNode} from '../operation-node/return-node.js'
+import type {VertexNode} from '../operation-node/vertex-node.js'
 import {isSurrealReturnType} from '../parser/return-parser.js'
-import {freeze} from '../util/object-utils.js'
+import {freeze, isReadonlyArray} from '../util/object-utils.js'
 
 export class SurrealDbQueryCompiler extends DefaultQueryCompiler {
   protected appendRootOperationNodeAsValue(node: RootOperationNode): void {
@@ -38,6 +39,7 @@ export class SurrealDbQueryCompiler extends DefaultQueryCompiler {
     CreateQueryNode: this.visitCreateQuery.bind(this),
     RelateQueryNode: this.visitRelateQuery.bind(this),
     ReturnNode: this.visitReturn.bind(this),
+    VertexNode: this.visitVertex.bind(this),
   })
 
   protected readonly superVisitNode = this.visitNode
@@ -79,28 +81,19 @@ export class SurrealDbQueryCompiler extends DefaultQueryCompiler {
   protected visitRelateQuery(node: RelateQueryNode): void {
     const {content, from, set, to} = node
 
-    this.append('relate ')
+    this.append('relate')
 
     if (from) {
-      if (SelectQueryNode.is(from) || RawNode.is(from)) {
-        this.appendRootOperationNodeAsValue(from)
-      } else {
-        this.visitNode(from as any)
-      }
-
+      this.append(' ')
+      this.visitNode(from as any)
       this.append(' -> ')
     }
 
-    this.visitNode(node.table)
+    this.visitNode(node.edge)
 
     if (to) {
       this.append(' -> ')
-
-      if (SelectQueryNode.is(to) || RawNode.is(to)) {
-        this.appendRootOperationNodeAsValue(to)
-      } else {
-        this.visitNode(to as any)
-      }
+      this.visitNode(to as any)
     }
 
     if (content) {
@@ -131,5 +124,19 @@ export class SurrealDbQueryCompiler extends DefaultQueryCompiler {
     }
 
     this.visitNode(node.return as any)
+  }
+
+  protected visitVertex(node: VertexNode): void {
+    const {vertex} = node
+
+    if (isReadonlyArray(vertex)) {
+      this.append('[')
+      this.compileList(vertex)
+      this.append(']')
+    } else if (SelectQueryNode.is(vertex) || RawNode.is(vertex)) {
+      this.appendRootOperationNodeAsValue(vertex)
+    } else {
+      this.visitNode(vertex)
+    }
   }
 }

--- a/src/surreal-kysely.ts
+++ b/src/surreal-kysely.ts
@@ -5,7 +5,7 @@ import {RelateQueryNode} from './operation-node/relate-query-node.js'
 import {CreateQueryBuilder} from './query-builder/create-query-builder.js'
 import {RelateQueryBuilder} from './query-builder/relate-query-builder.js'
 import {createQueryId} from './util/query-id.js'
-import type {SurrealDatabase, SurrealRecordId} from './util/surreal-types.js'
+import type {AnyEdge, SurrealDatabase, SurrealRecordId} from './util/surreal-types.js'
 
 /**
  * The main SurrealKysely class.
@@ -24,13 +24,11 @@ import type {SurrealDatabase, SurrealRecordId} from './util/surreal-types.js'
  * import {fetch} from 'undici'
  *
  * interface Person {
- *   id: Generated<string>
  *   first_name: string
  *   last_name: string
  * }
  *
  * interface Pet {
- *   id: Generated<string>
  *   name: string
  *   species: 'cat' | 'dog'
  * }
@@ -43,7 +41,7 @@ import type {SurrealDatabase, SurrealRecordId} from './util/surreal-types.js'
  *
  * interface Database {
  *   person: Person
- *   own: Own
+ *   own: SurrealEdge<Own>
  *   pet: Pet
  * }
  *
@@ -122,8 +120,8 @@ export class SurrealKysely<DB> extends Kysely<SurrealDatabase<DB>> {
     const ref = id !== undefined ? `${String(target)}:${id}` : String(target)
 
     return new CreateQueryBuilder({
-      queryId: createQueryId(),
       executor: this.getExecutor(),
+      queryId: createQueryId(),
       queryNode: CreateQueryNode.create(TableNode.create(ref)),
     })
   }
@@ -131,8 +129,10 @@ export class SurrealKysely<DB> extends Kysely<SurrealDatabase<DB>> {
   /**
    * Creates a relate query.
    *
-   * This query returns the create relation by default. See the {@link RelateQueryBuilder.return | return}
+   * This query returns the created relation by default. See the {@link RelateQueryBuilder.return | return}
    * method for a way to control the returned data.
+   *
+   * This method only accepts tables that are defined as {@link SurrealEdge}s.
    *
    * ### Examples
    *
@@ -184,11 +184,11 @@ export class SurrealKysely<DB> extends Kysely<SurrealDatabase<DB>> {
    * relate $1 -> like -> $2 set time.connected = time::now();
    * ```
    */
-  relate<TB extends keyof DB>(table: TB): RelateQueryBuilder<SurrealDatabase<DB>, TB> {
+  relate<E extends AnyEdge<DB>>(edge: E): RelateQueryBuilder<SurrealDatabase<DB>, E> {
     return new RelateQueryBuilder({
-      queryId: createQueryId(),
       executor: this.getExecutor(),
-      queryNode: RelateQueryNode.create(TableNode.create(table as string)),
+      queryId: createQueryId(),
+      queryNode: RelateQueryNode.create(TableNode.create(edge)),
     })
   }
 }

--- a/src/util/object-utils.ts
+++ b/src/util/object-utils.ts
@@ -1,3 +1,7 @@
 export function freeze<T>(obj: T): Readonly<T> {
   return Object.freeze(obj)
 }
+
+export function isReadonlyArray(obj: unknown): obj is ReadonlyArray<any> {
+  return Array.isArray(obj)
+}

--- a/src/util/surreal-types.ts
+++ b/src/util/surreal-types.ts
@@ -1,11 +1,114 @@
-export type SurrealDatabase<DB> = DB & {
-  [K in SurrealRecordId<DB>]: K extends `${infer TB}:${string}` ? (TB extends keyof DB ? DB[TB] : never) : never
+import type {ColumnType, GeneratedAlways} from 'kysely'
+
+/**
+ * Enhances a regular database interface with SurrealDB stuff.
+ *
+ * Automatically adds id columns, and edges' (see {@link SurrealEdge}) in-out columns
+ * so you don't have to.
+ *
+ * When using {@link SurrealKysely}, you only need to pass your regular database
+ * interface - the wrapper does the wrapping for you under the hood.
+ *
+ * ### Examples
+ *
+ * ```ts
+ * interface Person {
+ *   first_name: string
+ *   last_name: string
+ * }
+ *
+ * interface Pet {
+ *   name: string
+ *   species: 'cat' | 'dog'
+ * }
+ *
+ * interface Own {
+ *   time: {
+ *     adopted: string
+ *   }
+ * }
+ *
+ * interface Database {
+ *   person: Person
+ *   own: SurrealEdge<Own>
+ *   pet: Pet
+ * }
+ *
+ * SurrealDatabase<Database>
+ * ```
+ *
+ * @typeParam DB - The database interface type. Keys of this type must be table names
+ *    in the database and values must be interfaces that describe the rows in those
+ *    tables. See the examples above.
+ */
+export type SurrealDatabase<DB> = {
+  [K in keyof DB | SurrealRecordId<DB>]: K extends `${infer TB}:${string}`
+    ? TB extends keyof DB
+      ? SurrealRecordOrEdge<DB, TB>
+      : never
+    : K extends keyof DB
+    ? SurrealRecordOrEdge<DB, K>
+    : never
 }
 
-export type SurrealRecordId<DB> = keyof DB extends string ? `${keyof DB}:${string}` : never
+export type SurrealRecordId<DB, TB extends keyof DB = keyof DB> = TB extends string ? `${TB}:${string}` : never
 
-export type AnyTable<DB, TB extends keyof DB = keyof DB> = TB extends `${infer T}:${string}`
-  ? T
-  : TB extends string
-  ? TB
-  : never
+export type SurrealRecordOrEdge<DB, TB extends keyof DB> = DB[TB] extends SurrealEdge<any>
+  ? {
+      [C in 'id' | 'in' | 'out' | keyof DB[TB]]: C extends 'id'
+        ? ColumnType<SurrealRecordId<DB, TB>, string | undefined, string | undefined>
+        : C extends 'in' | 'out'
+        ? GeneratedAlways<SurrealRecordId<DB>>
+        : C extends keyof DB[TB]
+        ? DB[TB][C]
+        : never
+    }
+  : SurrealRecord<DB, TB>
+
+export type SurrealRecord<DB, TB extends keyof DB> = {
+  [C in 'id' | keyof DB[TB]]: C extends 'id'
+    ? ColumnType<SurrealRecordId<DB, TB>, string | undefined, string | undefined>
+    : C extends keyof DB[TB]
+    ? DB[TB][C]
+    : never
+}
+
+/**
+ * Gives a hint to {@link SurrealDatabase} that the given table is a graph edge.
+ *
+ * These tables can act as graph edges between two records in {@link SurrealKysely.relate | relate}
+ * queries.
+ *
+ * ### Examples
+ *
+ * ```ts
+ * interface Database {
+ *   person: Person
+ *   own: SurrealEdge<Own>
+ *   pet: Pet
+ * }
+ * ```
+ *
+ * @typeParam E - An interface representing the edge's unreserved columns structure.
+ */
+export type SurrealEdge<E> = {
+  [K in '__edge' | keyof E]: K extends '__edge' ? ColumnType<never, never, never> : K extends keyof E ? E[K] : never
+}
+
+export type AnyEdge<DB> = {
+  [K in keyof DB]: DB[K] extends SurrealEdge<DB[K]> ? (K extends string ? K : never) : never
+}[keyof DB]
+
+export type AnySpecificVertex<DB> = {
+  [K in keyof DB]: DB[K] extends SurrealEdge<DB[K]> ? never : SurrealRecordId<DB, K>
+}[keyof DB]
+
+export type AnyVertexGroup<DB> = {
+  [K in keyof DB]: DB[K] extends AnyEdge<DB>
+    ? never
+    : K extends `${string}:${string}`
+    ? never
+    : K extends string
+    ? K
+    : never
+}[keyof DB]

--- a/src/util/surreal-types.ts
+++ b/src/util/surreal-types.ts
@@ -104,7 +104,7 @@ export type AnySpecificVertex<DB> = {
 }[keyof DB]
 
 export type AnyVertexGroup<DB> = {
-  [K in keyof DB]: DB[K] extends AnyEdge<DB>
+  [K in keyof DB]: K extends AnyEdge<DB>
     ? never
     : K extends `${string}:${string}`
     ? never

--- a/tests/nodejs/surreal-kysely/create.test.ts
+++ b/tests/nodejs/surreal-kysely/create.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai'
 
 import type {SurrealKysely} from '../../../src'
-import {dropTable, getDb, testSurrealQl, type Database} from './shared'
+import {dropTables, getDb, testSurrealQl, type Database} from './shared'
 
 describe('SurrealKysely.create(...)', () => {
   let db: SurrealKysely<Database>
@@ -11,7 +11,7 @@ describe('SurrealKysely.create(...)', () => {
   })
 
   after(async () => {
-    await dropTable('person')
+    await dropTables(['person'])
   })
 
   it('should execute a create...set query with a random id.', async () => {


### PR DESCRIPTION
- introduce edge hints (`SurrealEdge<E>`).
- limit `relate(edge)` to just edges.
- limit `from(...)` & `to(...)` to just vertices.
- multiple specific records `from`/`to` overloads.
