### PR TITLE
fixes `resolveBasePath` for `127.0.0.1`

### DIFF
--- a/src/dialect/shared.ts
+++ b/src/dialect/shared.ts
@@ -1,7 +1,7 @@
 import type {CompiledQuery} from 'kysely'
 
 export function resolveBasePath(hostname: string): string {
-  const protocol = hostname.startsWith('localhost') ? 'http' : 'https'
+  const protocol = hostname.startsWith('localhost') || hostname.startsWith('127.0.0.1') ? 'http' : 'https'
 
   return `${protocol}://${hostname}`
 }


### PR DESCRIPTION
[Using `127.0.0.1` instead of using `localhost`](https://github.com/igalklebanov/kysely-surrealdb/issues/11#issuecomment-1556511438) currently throws the following error:
```node
Error: write EPROTO FC630000:error:0A00010B:SSL routines:ssl3_get_record:wrong version number:c:\ws\deps\openssl\openssl\ssl\record\ssl3_record.c:355:

    at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:94:16) {
  errno: -4046,
  code: 'EPROTO',
  syscall: 'write'
}
```
This is because currently everything that isn't `localhost` will use the https protocol, which means that `127.0.0.1` would also use the https protocol. This PR adds an exception to `127.0.0.1` too, which fixes the issue.

Closes: #11